### PR TITLE
Update AuthClient.swift

### DIFF
--- a/MojioSDK/Client/AuthClient.swift
+++ b/MojioSDK/Client/AuthClient.swift
@@ -12,13 +12,13 @@ import Alamofire
 import SwiftyJSON
 
 // OAuth 2.0 Object - RFC 6749
-public class AuthToken  {
+public class AuthToken : NSObject {
     public dynamic var accessToken : String? = nil
     public dynamic var expiry : String? = nil
     public dynamic var refreshToken : String? = nil
     public dynamic var uniqueId : String? = nil
     
-    init() {
+    override init() {
 
     }
     


### PR DESCRIPTION
In develop branch the AuthClient class does not show methods having Custom classes like method having AuthToken as parameters.

The changes resolve the problem.
