### PR TITLE
fixed date formatting for the `since` date

### DIFF
--- a/MojioSDK/Client/RestClient.swift
+++ b/MojioSDK/Client/RestClient.swift
@@ -99,7 +99,7 @@ open class RestClient {
     fileprivate var nextUrl: String? = nil
     fileprivate var sinceBeforeFormatter = DateFormatter()
     fileprivate static let SinceBeforeDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-    fileprivate static let SinceBeforeTimezone = TimeZone(abbreviation: "UTC");
+    fileprivate static let SinceBeforeTimezone = TimeZone(abbreviation: "UTC")
     fileprivate var dispatchQueue = RestClient.defaultDispatchQueue
     
     internal let sessionManager: SessionManager
@@ -116,6 +116,7 @@ open class RestClient {
     private func initDateFormatters() {
         self.sinceBeforeFormatter.dateFormat = RestClient.SinceBeforeDateFormat
         self.sinceBeforeFormatter.timeZone = RestClient.SinceBeforeTimezone
+        self.sinceBeforeFormatter.locale = Locale(identifier: "en_US_POSIX")
     }
     
     open func get() -> Self {


### PR DESCRIPTION
If the device has a UK locale and a 12-hour time format, DateFormatter adds AM/PM characters into the formatted string. Platform can't parse the date in this format. Setting `en_US_POSIX` locale to the formatter fixes this behavior.