### PR TITLE
MB-3732 TDG QA 178: iOS: Re-login in iOS App necessary

### DIFF
--- a/MojioSDK/Client/AuthClient.swift
+++ b/MojioSDK/Client/AuthClient.swift
@@ -281,25 +281,24 @@ open class AuthClient: AuthControllerDelegate {
             return
         }
         
-        // Always attempt to refresh
-        if let _ = authToken.refreshToken {
+        guard let timestamp = authToken.expiryTimestamp() else {
+            failure(nil)
+            return
+        }
+        
+        let currentTime = Date().timeIntervalSince1970
+        let hourInterval : Double = 60 * 60
+        let almostOrAlreadyExpired = currentTime > (timestamp - hourInterval)
+        
+        // Attempt to refresh when almost (1 hour left) or already expired
+        if let _ = authToken.refreshToken, almostOrAlreadyExpired {
             self.refreshAuthToken(completion, failure: failure)
         }
-        else {
-            // Check if the token is expired
-            guard let timestamp = authToken.expiryTimestamp() else {
-                failure(nil)
-                return
-            }
-            
-            let currentTime = Date().timeIntervalSince1970
-            
-            // Check for expiry
-            if currentTime > timestamp {
-                failure(nil)
-            }
-            
+        else if !almostOrAlreadyExpired {
             completion(authToken)
+        }
+        else {
+            failure(nil)
         }
     }
     


### PR DESCRIPTION
Refresh auth token only if it's close to expiring

Suresh Venkatraman added a comment
- Only refresh auth token when less than 1 hour from expiry.