### PR TITLE
using value "deviceId" for property "device.id"

### DIFF
--- a/MojioSDK/Models/Pets/Device.swift
+++ b/MojioSDK/Models/Pets/Device.swift
@@ -75,7 +75,7 @@ public struct Device: DeviceModel {
     public let gatewayTime: Date?
     
     public var id: String {
-        return self.imei
+        return self.deviceId
     }
     
     public enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
Using value of "deviceId" instead of "imei" for "id" property of pet's devices to avoid confusing during detecting relations between assets and devices.