### PR TITLE
PHIOS-2632: added url query parameters to multipart request

### DIFF
--- a/MojioSDK/Client/Images/ImagesClient.swift
+++ b/MojioSDK/Client/Images/ImagesClient.swift
@@ -61,17 +61,25 @@ open class ImagesClient: RestClient {
         return self
     }
     
-    open func uploadImage(_ imageData: Data, mimeType: MimeType.Image, completion: @escaping (Image?) -> Void, failure: @escaping (Any?) -> Void) {
-        return self.uploadImage(imageData, mimeType: mimeType, completion: {response, headers in completion(response as? Image)}, failure: failure)
+    open func uploadImage(_ imageData: Data,
+                          mimeType: MimeType.Image,
+                          urlParams: [String: Any]? = nil,
+                          completion: @escaping (Image?) -> Void,
+                          failure: @escaping (Any?) -> Void) {
+        return self.uploadImage(imageData, mimeType: mimeType, urlParams: urlParams, completion: {response, headers in completion(response as? Image)}, failure: failure)
     }
 
-    open func uploadImage<I: ImageModel>(_ imageData: Data, mimeType: MimeType.Image, completion: @escaping (I?) -> Void, failure: @escaping (Any?) -> Void) {
-        return self.uploadImage(imageData, mimeType: mimeType, completion: {response, headers in completion(response as? I)}, failure: failure)
+    open func uploadImage<I: ImageModel>(_ imageData: Data,
+                                         mimeType: MimeType.Image,
+                                         urlParams: [String: Any]? = nil,
+                                         completion: @escaping (I?) -> Void,
+                                         failure: @escaping (Any?) -> Void) {
+        return self.uploadImage(imageData, mimeType: mimeType, urlParams: urlParams, completion: {response, headers in completion(response as? I)}, failure: failure)
     }
     
-    internal func uploadImage(_ imageData: Data, mimeType: MimeType.Image, completion: @escaping (_ response: Codable?, _ headers: [String : String]) -> Void, failure: @escaping (_ error: Any?) -> Void) {
+    internal func uploadImage(_ imageData: Data, mimeType: MimeType.Image, urlParams: [String: Any]? = nil, completion: @escaping (_ response: Codable?, _ headers: [String : String]) -> Void, failure: @escaping (_ error: Any?) -> Void) {
         
-        guard let requestUrl = self.requestUrl else {
+        guard let requestUrl = self.requestUrl.flatMap({ URL(string: $0) }) else {
             failure(nil)
             return
         }
@@ -80,11 +88,13 @@ open class ImagesClient: RestClient {
         let name = "ImagesClient.ImageData"
         let fileName = "\(name).\(version)"
         
+        let encodedUrl = (try? URLEncoding(destination: .queryString, boolEncoding: .literal).encode(URLRequest(url: requestUrl), with: urlParams))?.url ?? requestUrl
+        
         self.sessionManager.upload(
             multipartFormData: {multipartFormData in
                 multipartFormData.append(imageData, withName: name, fileName: fileName, mimeType: mimeType.rawValue)
         },
-            to: requestUrl,
+            to: encodedUrl,
             headers: self.defaultHeaders) {result in
                 
                 switch result {


### PR DESCRIPTION
# [PHIOS-2632](https://1mojio.atlassian.net/browse/PHIOS-2632): encrypt images

Added url parameters to uploading images request 

## Platform isn't ready yet
As that feature isn't ready yet it shouldn't be merged. According to Mauro's [comment](https://1mojio.atlassian.net/browse/PHIOS-2632?focusedCommentId=90132&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-90132) that's not implemented on platform side and shouldn't be merged.