### PR TITLE
PHIOS-2796 added Equatable extension for AppearanceImage

### DIFF
--- a/MojioSDK/Models/Vehicles/VehicleAppearance.swift
+++ b/MojioSDK/Models/Vehicles/VehicleAppearance.swift
@@ -65,7 +65,13 @@ public struct VehicleAppearance: Codable {
 extension VehicleAppearance: Equatable {
     public static func == (lhs: VehicleAppearance, rhs: VehicleAppearance) -> Bool {
         return lhs.vehicleId == rhs.vehicleId && lhs.color == rhs.color &&
-            lhs.icon == rhs.icon && lhs.showOnMap == rhs.showOnMap
+            lhs.icon == rhs.icon && lhs.showOnMap == rhs.showOnMap && lhs.vehicleImage == rhs.vehicleImage
+    }
+}
+
+extension VehicleAppearance.VehicleImage: Equatable {
+    public static func ==(lhs: VehicleAppearance.VehicleImage, rhs: VehicleAppearance.VehicleImage) -> Bool {
+        return lhs.url == rhs.url && lhs.hexColor == rhs.hexColor
     }
 }
 


### PR DESCRIPTION
# [PHIOS-2796](https://1mojio.atlassian.net/browse/PHIOS-2796): Equatable extension for Images
This PR provides Equatable extension for Appearances Images to have an ability to use Distinct Changes in fetching appearances