### PR TITLE
Add public member-wise initializer.

### DIFF
--- a/MojioSDK/Models/Vehicles/AggregationData.swift
+++ b/MojioSDK/Models/Vehicles/AggregationData.swift
@@ -55,6 +55,19 @@ public struct AggregationData: AggregationDataModel {
         case tripCount = "TripCount"
     }
     
+    public init(total: Double, average: Double, max: Double, min: Double, units: String?, date: Date?, endDate: Date?, count: Int, tripCount: Int) {
+        
+        self.total = total
+        self.average = average
+        self.max = max
+        self.min = min
+        self.units = units
+        self.date = date
+        self.endDate = endDate
+        self.count = count
+        self.tripCount = tripCount
+    }
+    
     public init(from decoder: Decoder) throws {
         
         do {


### PR DESCRIPTION
Add public member-wise initializer in AggregateData. This is to get around new swift5 [restriction.]( https://forums.swift.org/t/review-se-0189-restrict-cross-module-struct-initializers/7066)

See changes proposed in extension [here](https://github.com/mojio/Phoenix-iOS/pull/2281).