### PR TITLE
TDE-2220: Added missed None case to EngineOilLevelWarning enum

### DIFF
--- a/MojioSDK/Models/Vehicles/EngineOil.swift
+++ b/MojioSDK/Models/Vehicles/EngineOil.swift
@@ -19,6 +19,7 @@ public enum EngineOilLevelWarning: String, Codable {
     case veryLow = "Very Low"
     case low = "Low"
     case high = "High"
+    case none = "None"
     case unknown = "Unknown"
     
     public init(from decoder: Decoder) throws {


### PR DESCRIPTION
Related to:
https://1mojio.atlassian.net/browse/TDE-2220

* Added missed None case to EngineOilLevelWarning enum;