### PR TITLE
PHIOS-5023 [iOS] Sensitive Data Exposure: access_token,clientId &amp;…

### DIFF
--- a/MojioSDKClient/AppDelegate.swift
+++ b/MojioSDKClient/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         
         MojioClientEnvironment.SharedInstance.setRegion(MojioClientRegion.NAStaging)
-        let authClient : MojioAuth = MojioAuth (clientId: "81d705ec-4025-4d96-9b30-53d2a43eaa24", clientSecretKey: "2299d863-5a3a-4aea-8bd1-0caf32a412d5", clientRedirectURI: "sdkdev://io.moj")
+        let authClient : MojioAuth = MojioAuth (clientId: "<CLIENT_ID>", clientSecretKey: "<CLIENT_SECRET>", clientRedirectURI: "sdkdev://io.moj")
         authClient.login( {
             print("user is logged in");
             let viewController : UIViewController = UIStoryboard.init(name: "Main", bundle: NSBundle.mainBundle()).instantiateInitialViewController()!;

--- a/MojioSDKTests/AuthenticationTests.swift
+++ b/MojioSDKTests/AuthenticationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class AuthenticationTests: XCTestCase {
     
-    let authClient : AuthClient = AuthClient(clientId: "81d705ec-4025-4d96-9b30-53d2a43eaa24", clientSecretKey: "2299d863-5a3a-4aea-8bd1-0caf32a412d5", clientRedirectURI: "sdkdev://io.moj")
+    let authClient : AuthClient = AuthClient(clientId: "<CLIENT_ID>", clientSecretKey: "<CLIENT_SECRET>", clientRedirectURI: "sdkdev://io.moj")
     
     override func setUp() {
         super.setUp()
@@ -71,7 +71,7 @@ class AuthenticationTests: XCTestCase {
     
     func performLogin () {
         
-        let urlRequest : NSURLRequest = NSURLRequest(URL: NSURL(string: "sdkdev://io.moj#access_token=9be67364-3f78-4539-ae64-5861c4dd3584&token_type=bearer&expires_in=43200")!)
+        let urlRequest : NSURLRequest = NSURLRequest(URL: NSURL(string: "sdkdev://io.moj#access_token=<ACCESS-TOKEN>&token_type=bearer&expires_in=43200")!)
         
         self.authClient.loginCompletion = { (authToken) in
             XCTAssert(true, "Login successful")

--- a/MojioSDKTests/BaseApiTest.swift
+++ b/MojioSDKTests/BaseApiTest.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class BaseApiTest: XCTestCase {
     
-    let authClient : AuthClient = AuthClient(clientId: "81d705ec-4025-4d96-9b30-53d2a43eaa24", clientSecretKey: "2299d863-5a3a-4aea-8bd1-0caf32a412d5", clientRedirectURI: "sdkdev://io.moj")
+    let authClient : AuthClient = AuthClient(clientId: "<CLIENT_ID>", clientSecretKey: "<CLIENT_SECRET>", clientRedirectURI: "sdkdev://io.moj")
     
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
… clientSecretKey are being leaned in Mojio Git Hub repo.

https://1mojio.atlassian.net/browse/PHIOS-5023

⁉️ What does this PR do?

* Replaced GUIDs with <PLACEHOLDER>s

📖 Any background context you want to provide?

* According the https://docs.moj.io/#!/document/view/doc_ios to use Mojio SKD user should get keys from Moj.io 
* Master branch from iOS Mojio SDK is too old and outdated. Also according Kenneth these values also are outdated.
* Phoenix application doesn't have these values.

🔬 How should this be manually tested?

* Follow reproduction steps in linked ticket