### PR TITLE
implementation FORCE-1869: [iOS] the app should parse "vehicle.vin" value

### DIFF
--- a/MojioSDK/Extensions/CompoundWordStyle.swift
+++ b/MojioSDK/Extensions/CompoundWordStyle.swift
@@ -26,6 +26,13 @@ public extension RawRepresentable where Self: CompoundWordStyle, RawValue == Str
     }
     
     var lowerCamelCase: String {
-        return self.rawValue.decapitalizedFirstCharacter
+        let value = self.rawValue
+        if CharacterSet(charactersIn: value).isSubset(of: CharacterSet.uppercaseLetters.union(CharacterSet.decimalDigits)) {
+            // it is an abbreviation so change all letters to lowercase
+            return value.lowercased()
+        }
+        else {
+            return value.decapitalizedFirstCharacter
+        }
     }
 }


### PR DESCRIPTION
Platform sends vehicle vin value by using key "VIN" for Phoenix project and key "vin" for Force project.
So to handle this case was added checking of abbreviations in property "lowerCamelCase" of "CompoundWordStlyle".


https://1mojio.atlassian.net/browse/FORCE-1869