### PR TITLE
PHIOS-5989 [SPIKE] How do we handle platform errors on sign up, sign in, reset password on Phoenix

### DIFF
--- a/MojioSDK/Client/Accounts/AuthClient.swift
+++ b/MojioSDK/Client/Accounts/AuthClient.swift
@@ -651,7 +651,7 @@ extension AuthClient {
             headers.update(.authorization(bearerToken: accessToken))
         }
 
-        self.sessionManager
+        let request = self.sessionManager
             .request(endPoint, method: .post, parameters: parameters, encoding: URLEncoding.default, headers: headers)
         request
             .responseJSON(queue: self.dispatchQueue, options: .allowFragments) { response in

--- a/MojioSDK/Client/Accounts/AuthClient.swift
+++ b/MojioSDK/Client/Accounts/AuthClient.swift
@@ -254,7 +254,7 @@ open class AuthClient: AuthControllerDelegate {
     }
     
     // Login
-    open func login(_ token: String, firstName: String? = nil, lastName: String? = nil, email: String? = nil, customParameters: [String: Any]? = nil, , debug: ((_ request: Request?, _ response: AFDataResponse<Any>?) -> Void)? = nil, completion: @escaping (_ authToken: AuthToken) -> Void, failure: @escaping (_ response: [String: Any]?) -> Void) {
+    open func login(_ token: String, firstName: String? = nil, lastName: String? = nil, email: String? = nil, customParameters: [String: Any]? = nil, debug: ((_ request: Request?, _ response: AFDataResponse<Any>?) -> Void)? = nil, completion: @escaping (_ authToken: AuthToken) -> Void, failure: @escaping (_ response: [String: Any]?) -> Void) {
         
         // The token endpoint is used for the resource owner flow
         let loginEndpoint = self.tokenUrl


### PR DESCRIPTION
https://1mojio.atlassian.net/browse/PHIOS-5989

⁉️ What does this PR do?

Extended contracts of AuthClient to use external loggers

📖 Any background context you want to provide?

PHIOS-5207: post request notification for any loggers - wasn't implemented for AuthClient