### PR TITLE
[PHIOS-6988][Motion Free] Add "Beta" to environment switcher

### DIFF
--- a/MojioSDK/Env/ClientEnvironment.swift
+++ b/MojioSDK/Env/ClientEnvironment.swift
@@ -24,6 +24,7 @@ open class MojioRegion: MojioRegionPrefix {
     public enum RegionType: String {
         case production = "production-"
         case fut = "fut-"
+        case beta = "beta-"
         case staging = "staging-"
         case load = "load-"
         case develop = "develop-"


### PR DESCRIPTION
#### :tickets: Jira Tickets
https://1mojio.atlassian.net/browse/PHIOS-6988

#### :interrobang: What does this PR do?
Added "beta" to regiontype. Note this option in the env switcher will be available to all brands, but will currently only be functional for motion free using motion-us-phoenix environment.